### PR TITLE
Fix #5

### DIFF
--- a/lib/myrurema.rb
+++ b/lib/myrurema.rb
@@ -167,7 +167,7 @@ class MyRurema
     # if first several words are results of AND search
     lines.first(2).join.split(/\s+/).all? do |word|
       query.all? do |q|
-        word.include?(q)
+        word =~ Regexp.new(q, 'i')
       end
     end
   end


### PR DESCRIPTION
The cause of this bug is `query` is an array, so expanded in regex like

```
/["File"].*["File"]/m
```

It matches more than you expected.

I fixed this by checking all words include the query words.
I am not familier with bitclust's mechanism, so please fix if this check is too strict or too loose.
